### PR TITLE
PLACP-250 - add DotFingers SPM products and binary targets

### DIFF
--- a/.scripts/prepare_swift_package.sh
+++ b/.scripts/prepare_swift_package.sh
@@ -86,6 +86,21 @@ assert_zip_content DotPalmDetection.zip
 CHECKSUM=$(sha256sum DotPalmDetection.zip | awk '{print $1}')
 sed -i "s/{checksum_palm_detection}/$CHECKSUM/g" Package.swift
 
+curl -O "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-core/$RELEASE_VERSION/DotFingersCore.zip"
+assert_zip_content DotFingersCore.zip
+CHECKSUM=$(sha256sum DotFingersCore.zip | awk '{print $1}')
+sed -i "s/{checksum_fingers_core}/$CHECKSUM/g" Package.swift
+
+curl -O "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-detection/$RELEASE_VERSION/DotFingersDetection.zip"
+assert_zip_content DotFingersDetection.zip
+CHECKSUM=$(sha256sum DotFingersDetection.zip | awk '{print $1}')
+sed -i "s/{checksum_fingers_detection}/$CHECKSUM/g" Package.swift
+
+curl -O "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-transformation/$RELEASE_VERSION/DotFingersTransformation.zip"
+assert_zip_content DotFingersTransformation.zip
+CHECKSUM=$(sha256sum DotFingersTransformation.zip | awk '{print $1}')
+sed -i "s/{checksum_fingers_transformation}/$CHECKSUM/g" Package.swift
+
 curl -O "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-face-lite/$RELEASE_VERSION/DotFaceLite.zip"
 assert_zip_content DotFaceLite.zip
 CHECKSUM=$(sha256sum DotFaceLite.zip | awk '{print $1}')

--- a/.template/Package_template.swift
+++ b/.template/Package_template.swift
@@ -18,6 +18,12 @@ let package = Package(
             name: "DotPalmDetection",
             targets: ["DotPalmDetection", "DotPalmCore", "DotCore", "DotSerialization", "DotCamera", "DotProtocolBuffers", "DotCapture"]),
         .library(
+            name: "DotFingersDetection",
+            targets: ["DotFingersDetection", "DotFingersCore", "DotCore", "DotSerialization", "DotCamera", "DotProtocolBuffers", "DotCapture"]),
+        .library(
+            name: "DotFingersTransformation",
+            targets: ["DotFingersTransformation", "DotFingersCore", "DotCore", "DotSerialization", "DotCamera", "DotProtocolBuffers", "DotCapture"]),
+        .library(
             name: "DotDocumentBarcode",
             targets: ["DotDocumentBarcode", "DotDocument", "DotCore", "DotCapture"]
         ),
@@ -64,6 +70,9 @@ let package = Package(
         .binaryTarget(name: "DotDocumentBarcode", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-document-barcode/{version}/DotDocumentBarcode.zip", checksum: "{checksum_document_barcode}"),
         .binaryTarget(name: "DotPalmCore", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-palm-core/{version}/DotPalmCore.zip", checksum: "{checksum_palm_core}"),
         .binaryTarget(name: "DotPalmDetection", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-palm-detection/{version}/DotPalmDetection.zip", checksum: "{checksum_palm_detection}"),
+        .binaryTarget(name: "DotFingersCore", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-core/{version}/DotFingersCore.zip", checksum: "{checksum_fingers_core}"),
+        .binaryTarget(name: "DotFingersDetection", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-detection/{version}/DotFingersDetection.zip", checksum: "{checksum_fingers_detection}"),
+        .binaryTarget(name: "DotFingersTransformation", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-transformation/{version}/DotFingersTransformation.zip", checksum: "{checksum_fingers_transformation}"),
         .binaryTarget(name: "DotFaceLite", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-face-lite/{version}/DotFaceLite.zip", checksum: "{checksum_face_lite}"),
         .binaryTarget(name: "DotFaceCore", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-face-core/{version}/DotFaceCore.zip", checksum: "{checksum_face_core}"),
         .binaryTarget(name: "DotFaceVerification", url: "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-face-verification/{version}/DotFaceVerification.zip", checksum: "{checksum_verification}"),


### PR DESCRIPTION
## What

Scaffolds the new **DotFingers** modules into the Swift Package Manager distribution ahead of the public release.

- `.template/Package_template.swift`:
  - New library products: `DotFingersDetection`, `DotFingersTransformation`
  - New binary targets: `DotFingersCore`, `DotFingersDetection`, `DotFingersTransformation` (with `{version}` / `{checksum_*}` placeholders)
- `.scripts/prepare_swift_package.sh`: matching download + sha256 + sed blocks for the three new zips

`DotFingersCore` is a shared target bundled into both feature products (mirroring `DotPalmCore`), so it has no standalone product.

## How it works

Scaffold only — concrete version and checksums are filled by the `dot_ios_sdk_spm_release` workflow at release time, exactly like every other module. Must be merged to `main` before the SDK release pipeline dispatches the SPM stage.

## Notes

- Package-level platform stays `.iOS(.v13)` (package-wide). The Fingers xcframeworks carry their own min of **iOS 15.1**, enforced at link time.