### PR TITLE
PLACP-250 - rename DOT brand to IDV

### DIFF
--- a/.github/workflows/dot_ios_sdk_spm.yml
+++ b/.github/workflows/dot_ios_sdk_spm.yml
@@ -49,7 +49,7 @@ jobs:
           git config --global user.name 'Jakub Vallo'
           git config --global user.email 'jakub.vallo@innovatrics.com'
           git add -u
-          git commit -m "[dot_ios_sdk_spm_release workflow] release DOT iOS SDK Swift Package Manager $RELEASE_VERSION"
+          git commit -m "[dot_ios_sdk_spm_release workflow] release IDV iOS SDK Swift Package Manager $RELEASE_VERSION"
           git tag -a $RELEASE_VERSION -m "$RELEASE_VERSION"
           git push --follow-tags
         env:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # dot-ios-sdk-spm
-Innovatrics DOT iOS SDK Swift Package Manager repository.
+Innovatrics IDV iOS SDK Swift Package Manager repository.


### PR DESCRIPTION
Rename the DOT product name to IDV in the README and the release-workflow commit message, matching the SDK rebrand. `Package.swift` (code identifiers, product/target names, S3 URLs) is unchanged.